### PR TITLE
bug: failing test for batched search requests

### DIFF
--- a/lib/src/builders/search/contentSearchBuilder.ts
+++ b/lib/src/builders/search/contentSearchBuilder.ts
@@ -71,6 +71,6 @@ export class ContentSearchBuilder extends SearchRequestBuilder implements Search
 
             facets: this.facetBuilder.build(),
             sorting: this.sortingBuilder.build(),
-        };
+        } as ContentSearchRequest;
     }
 }

--- a/lib/src/builders/search/contentSearchBuilder.ts
+++ b/lib/src/builders/search/contentSearchBuilder.ts
@@ -60,6 +60,7 @@ export class ContentSearchBuilder extends SearchRequestBuilder implements Search
     public build(): ContentSearchRequest {
         const { take, skip } = this.paginationBuilder.build();
         return {
+            $type: 'Relewise.Client.Requests.Search.ContentSearchRequest, Relewise.Client', 
             ...this.baseBuild(),
             
             settings: this.searchSettings,

--- a/lib/src/builders/search/productSearchBuilder.ts
+++ b/lib/src/builders/search/productSearchBuilder.ts
@@ -82,6 +82,7 @@ export class ProductSearchBuilder extends SearchRequestBuilder implements Search
     public build(): ProductSearchRequest {
         const { take, skip } = this.paginationBuilder.build();
         return {
+            $type: 'Relewise.Client.Requests.Search.ProductSearchRequest, Relewise.Client',
             ...this.baseBuild(),
             take,
             skip,

--- a/lib/src/builders/search/productSearchBuilder.ts
+++ b/lib/src/builders/search/productSearchBuilder.ts
@@ -92,6 +92,6 @@ export class ProductSearchBuilder extends SearchRequestBuilder implements Search
             facets: this.facetBuilder.build(),
             settings: this.searchSettings,
             sorting: this.sortingBuilder.build(),
-        };
+        } as ProductSearchRequest;
     }
 }

--- a/lib/src/builders/search/searchTermPredictionBuilder.ts
+++ b/lib/src/builders/search/searchTermPredictionBuilder.ts
@@ -31,6 +31,7 @@ export class SearchTermPredictionBuilder extends SearchRequestBuilder {
 
     public build(): SearchTermPredictionRequest {
         return {
+            $type: 'Relewise.Client.Requests.Search.SearchTermPredictionRequest, Relewise.Client',
             ...this.baseBuild(),
 
             term: this.term,

--- a/lib/src/builders/search/searchTermPredictionBuilder.ts
+++ b/lib/src/builders/search/searchTermPredictionBuilder.ts
@@ -40,6 +40,6 @@ export class SearchTermPredictionBuilder extends SearchRequestBuilder {
                 $type: 'Relewise.Client.Requests.Search.Settings.SearchTermPredictionSettings, Relewise.Client',
                 targetEntityTypes: this.targetEntityTypes,
             },
-        };
+        } as SearchTermPredictionRequest;
     }
 }

--- a/lib/tests/integration-tests/batchedSearches.integration.test.ts
+++ b/lib/tests/integration-tests/batchedSearches.integration.test.ts
@@ -1,0 +1,31 @@
+import { ProductSearchBuilder, SearchCollectionBuilder, Searcher, SearchTermPredictionBuilder, SearchTermPredictionRequest, UserFactory } from '../../src';
+import { test, expect } from '@jest/globals'
+
+const { npm_config_API_KEY: API_KEY, npm_config_DATASET_ID: DATASET_ID, npm_config_SERVER_URL: SERVER_URL } = process.env;
+
+const searcher = new Searcher(DATASET_ID!, API_KEY!, { serverUrl: SERVER_URL });
+
+const settings = {
+    language: 'en-US',
+    currency: 'USD',
+    displayedAtLocation: 'integration test',
+    user: UserFactory.anonymous(),
+};
+
+test('Batched search requests', async() => {
+
+    const request = new SearchCollectionBuilder({
+        language: 'en-US',
+        currency: 'USD',
+        displayedAtLocation: 'integration test',
+        user: UserFactory.anonymous(),
+    })
+        .addRequest(new SearchTermPredictionBuilder(settings).build())
+        .addRequest(new ProductSearchBuilder(settings).setTerm('a').build())
+        .build();
+
+
+    const result = await searcher.batch(request);
+
+    expect(result?.responses?.length).toBe(2);
+});


### PR DESCRIPTION
We sadly have a bug in batched search requests. Here is a failing unit test.

We need to have the `$type` property on the Request-objects for this to be working.