### PR TITLE
feat: print errors to console

### DIFF
--- a/packages/client/src/relewise.client.ts
+++ b/packages/client/src/relewise.client.ts
@@ -72,14 +72,16 @@ export abstract class RelewiseClient {
             } catch (_) { 
             }
 
+            console.error(responseMessage);
+
             throw new ProblemDetailsError('Error when calling the Relewise API. Read more in the details property if there is error response or look in the network tab.', responseMessage);
         }
 
         try {
             const responseMessage = await response.json();
-
             return responseMessage as TResponse;
         } catch (err) {
+            console.error(err);
             return undefined;
         }
     }


### PR DESCRIPTION
Will now also print this as an error to the console:

![image](https://github.com/user-attachments/assets/6d8052e8-cb9a-444d-a577-81c42309b267)
