### PR TITLE
Support keepalive request option

### DIFF
--- a/packages/client/src/relewise.client.ts
+++ b/packages/client/src/relewise.client.ts
@@ -7,6 +7,7 @@ export interface RelewiseClientOptions {
 
 export interface RelewiseRequestOptions {
     abortSignal?: AbortSignal;
+    keepalive?: boolean;
 }
 
 export class ProblemDetailsError extends Error {
@@ -68,6 +69,7 @@ export abstract class RelewiseClient {
                 },
                 body: JSON.stringify(data),
                 signal: options?.abortSignal,
+                keepalive: options?.keepalive,
                 cache: this.cache,
             });
 

--- a/packages/client/src/relewise.client.ts
+++ b/packages/client/src/relewise.client.ts
@@ -6,7 +6,9 @@ export interface RelewiseClientOptions {
 }
 
 export interface RelewiseRequestOptions {
+    /** Cancels the request when the provided abort signal is triggered. */
     abortSignal?: AbortSignal;
+    /** Allows the request to outlive the page, such as when tracking events during page unload or navigation. */
     keepalive?: boolean;
 }
 

--- a/packages/client/tests/unit-tests/relewiseRequestOptions.unit.test.ts
+++ b/packages/client/tests/unit-tests/relewiseRequestOptions.unit.test.ts
@@ -1,0 +1,33 @@
+import { Tracker } from '../../src/tracker';
+
+describe('RelewiseRequestOptions', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        jest.restoreAllMocks();
+    });
+
+    test('passes keepalive to fetch when tracking events', async () => {
+        const fetchMock = jest.fn().mockResolvedValue({
+            ok: true,
+            json: jest.fn().mockRejectedValue(new Error('No content')),
+        } as unknown as Response);
+
+        global.fetch = fetchMock;
+
+        const tracker = new Tracker('dataset-id', 'api-key');
+
+        await tracker.trackProductView({
+            productId: 'product-id',
+            user: {
+                temporaryId: 'temporary-id',
+            },
+        }, { keepalive: true });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+            keepalive: true,
+        }));
+    });
+});


### PR DESCRIPTION
https://trello.com/c/xt2jRYcz/21073-support-keepalive-for-javascript-sdk-tracking-requests

## What changed
- Added `keepalive?: boolean` to `RelewiseRequestOptions`.
- Passed the option through to the shared `fetch` request configuration.
- Added a unit test covering keepalive propagation from a tracking request.

## Why
Tracking events can benefit from fetch keepalive when requests are sent during navigation or page lifecycle transitions.

## Validation
- `npm test`
- `npm run build`
- `npm run build:types`

`npm run lint` was attempted but is currently blocked because ESLint 10 expects `eslint.config.*`, while this package still uses `.eslintrc.js`.