### PR TITLE
fix: restore code analyzer ingest

### DIFF
--- a/packages/code-analyzer/package-lock.json
+++ b/packages/code-analyzer/package-lock.json
@@ -12,6 +12,7 @@
         "ts-morph": "^28.0.0"
       },
       "devDependencies": {
+        "@types/node": "^26.1.2",
         "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^10.8.0",
         "ts-node": "^10.9.2",
@@ -279,14 +280,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.7.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.2.tgz",
-      "integrity": "sha512-/NbVmcGTP+lj5oa4yiYxxeBjRivKQ5Ns1eSZeB99ExsEQ6rX5XYU1Zy/gGxY/ilqtD4Etx9mKyrPxZRetiahhA==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "undici-types": "~7.14.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -1247,12 +1247,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
-      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/packages/code-analyzer/package.json
+++ b/packages/code-analyzer/package.json
@@ -10,6 +10,7 @@
   "author": "Relewise",
   "license": "ISC",
   "devDependencies": {
+    "@types/node": "^26.1.2",
     "@typescript-eslint/parser": "^8.65.0",
     "eslint": "^10.8.0",
     "ts-node": "^10.9.2",

--- a/packages/code-analyzer/src/handlers/handleClasses.ts
+++ b/packages/code-analyzer/src/handlers/handleClasses.ts
@@ -19,13 +19,13 @@ export function handleClasses(sourceFile: SourceFile): Entry[] {
 
         classes.push({
             kind: Kind[Kind.Class],
-            name: cls.getName(),
+            name: cls.getName() ?? 'default',
             docs: cls.getJsDocs()[0]?.getText(),
             dependencies: properties.map(x => x.baseType),
             isAbstract: cls.isAbstract(),
             isDefault: cls.isDefaultExport(),
             properties: properties,
-            extends: ex ? [ex] : null,
+            extends: ex ? [ex] : undefined,
         });
     }
 

--- a/packages/code-analyzer/src/handlers/handleFunctions.ts
+++ b/packages/code-analyzer/src/handlers/handleFunctions.ts
@@ -9,7 +9,7 @@ export function handleFunctions(sourceFile: SourceFile): Entry[] {
     sourceFile.getFunctions().forEach(m => {
         functions.push({
             kind: Kind[Kind.Method],
-            name: m.getName(),
+            name: m.getName() ?? 'default',
             docs: m.getJsDocs()[0]?.getText(),
             dependencies: findParameterDependencies(m.getParameters()),
             parameters: handleParameters(m.getParameters()),

--- a/packages/code-analyzer/src/handlers/handleParameters.ts
+++ b/packages/code-analyzer/src/handlers/handleParameters.ts
@@ -13,7 +13,7 @@ export function handleParameters(parameters: ParameterDeclaration[]): Parameter[
         const nullable = param.hasQuestionToken();
 
         const initializer = param.getInitializer();
-        const defaultValue = initializer ? initializer.getText() : null;
+        const defaultValue = initializer?.getText();
 
         results.push({
             name,
@@ -58,7 +58,7 @@ export function findParameterDependencies(parameters: ParameterDeclaration[]): s
         const scope = param.getScope();
 
         if (scope === Scope.Private || scope === Scope.Protected) {
-            return;
+            continue;
         }
 
         const typeNode = param.getTypeNode();

--- a/packages/code-analyzer/src/handlers/handleProperties.ts
+++ b/packages/code-analyzer/src/handlers/handleProperties.ts
@@ -16,7 +16,7 @@ export function handleProperties(properties: PropertyDeclaration[]): Property[] 
         const type = typeNode ? typeNode.getText() : p.getType().getSymbol()?.getName();
 
         const initializer = p.getInitializer();
-        const defaultValue = initializer ? initializer.getText() : null;
+        const defaultValue = initializer?.getText();
 
         return {
             name: p.getName(),
@@ -24,7 +24,7 @@ export function handleProperties(properties: PropertyDeclaration[]): Property[] 
             docs: p.getJsDocs()[0]?.getText(),
             nullable: p.hasQuestionToken(),
             defaultValue: defaultValue,
-            baseType: getBaseType(p.getType()),
+            baseType: getBaseType(p.getType()) ?? 'unknown',
         };
     });
 }
@@ -37,7 +37,7 @@ export function handlePropertySignatures(properties: PropertySignature[]): Prope
         } 
     
         const initializer = p.getInitializer();
-        const defaultValue = initializer ? initializer.getText() : null;
+        const defaultValue = initializer?.getText();
 
         return {
             name: p.getName(),
@@ -45,7 +45,7 @@ export function handlePropertySignatures(properties: PropertySignature[]): Prope
             docs: p.getJsDocs()[0]?.getText(),
             nullable: p.hasQuestionToken(),
             defaultValue: defaultValue,
-            baseType: getBaseType(p.getType()),
+            baseType: getBaseType(p.getType()) ?? 'unknown',
         };
     });
 }

--- a/packages/code-analyzer/tsconfig.json
+++ b/packages/code-analyzer/tsconfig.json
@@ -5,7 +5,10 @@
         "target": "es6",
         "moduleResolution": "node",
         "sourceMap": true,
-        "outDir": "dist"
+        "outDir": "dist",
+        "types": [
+            "node"
+        ]
     },
     "lib": [
         "es2015"


### PR DESCRIPTION
https://trello.com/c/imUcysvy/21187-js-sdk-mcp-integration-is-failing

## Summary
- Add Node type definitions to `packages/code-analyzer` and explicitly include Node types in its TypeScript config.
- Fix stricter TypeScript compile errors in analyzer handlers exposed by the upgraded toolchain.
- Keep the generated ingestion payload shape aligned with the analyzer model types by omitting optional values instead of writing `null` where the model does not allow it.

## Root Cause
The MCP ingest workflow runs `ts-node ./src/main.ts`, which uses Node APIs (`fs`, `process`) but `code-analyzer` did not declare Node typings directly or include them in `tsconfig.json`. After dependency updates, transitive Node globals were no longer available. The newer TypeScript/tooling also surfaced existing `null`/`undefined` mismatches in handler return objects.

## Validation
- `npm --prefix .\packages\code-analyzer run codeAnalyzer -- '..\client\tsconfig.json' '@relewise/client'`
- `npm --prefix .\packages\code-analyzer run codeAnalyzer -- '..\integrations\tsconfig.json' '@relewise/integrations'`
- `npm --prefix .\packages\code-analyzer run lint`
- `npm --prefix .\packages\code-analyzer audit --audit-level=low`
